### PR TITLE
Make the engine oblivious of the data passed between map reloads #2066

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -85,7 +85,22 @@ public:
 
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) = 0;
 
-	virtual void OnClientConnected(int ClientID, bool AsSpec) = 0;
+	// Called before map reload, for any data that the game wants to
+	// persist to the next map.
+	//
+	// Has the size of the return value of `PersistentClientDataSize()`.
+	//
+	// Returns whether the game should be supplied with the data when the
+	// client connects for the next map.
+	virtual bool OnClientDataPersist(int ClientID, void *pData) = 0;
+
+	// Called when a client connects.
+	//
+	// If it is reconnecting to the game after a map change, the
+	// `pPersistentData` point is nonnull and contains the data the game
+	// previously stored.
+	virtual void OnClientConnected(int ClientID, void *pPersistentData) = 0;
+
 	virtual void OnClientEnter(int ClientID) = 0;
 	virtual void OnClientDrop(int ClientID, const char *pReason) = 0;
 	virtual void OnClientDirectInput(int ClientID, void *pInput) = 0;
@@ -93,7 +108,8 @@ public:
 
 	virtual bool IsClientReady(int ClientID) const = 0;
 	virtual bool IsClientPlayer(int ClientID) const = 0;
-	virtual bool IsClientSpectator(int ClientID) const = 0;
+
+	virtual int PersistentClientDataSize() const = 0;
 
 	virtual const char *GameType() const = 0;
 	virtual const char *Version() const = 0;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -92,7 +92,6 @@ public:
 			STATE_EMPTY = 0,
 			STATE_AUTH,
 			STATE_CONNECTING,
-			STATE_CONNECTING_AS_SPEC,
 			STATE_READY,
 			STATE_INGAME,
 
@@ -134,6 +133,9 @@ public:
 		bool m_Quitting;
 		const IConsole::CCommandInfo *m_pRconCmdToSend;
 		const CMapListEntry *m_pMapListEntryToSend;
+
+		bool m_HasPersistentData;
+		void *m_pPersistentData;
 
 		void Reset();
 	};

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -656,9 +656,25 @@ void CGameContext::OnClientEnter(int ClientID)
 	}
 }
 
-void CGameContext::OnClientConnected(int ClientID, bool Dummy, bool AsSpec)
+bool CGameContext::OnClientDataPersist(int ClientID, void *pData)
 {
-	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, ClientID, Dummy, AsSpec);
+	CPersistentClientData *pPersistent = (CPersistentClientData *)pData;
+	if(!m_apPlayers[ClientID])
+	{
+		return false;
+	}
+	pPersistent->m_IsSpectator = m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS;
+	return true;
+}
+
+void CGameContext::OnClientConnected(int ClientID, bool Dummy, CPersistentClientData *pPersistent)
+{
+	bool Spec = false;
+	if(pPersistent)
+	{
+		Spec = pPersistent->m_IsSpectator;
+	}
+	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, ClientID, Dummy, Spec);
 
 	if(Dummy)
 		return;
@@ -1482,7 +1498,7 @@ void CGameContext::OnInit()
 	if(g_Config.m_DbgDummies)
 	{
 		for(int i = 0; i < g_Config.m_DbgDummies ; i++)
-			OnClientConnected(Server()->MaxClients() -i-1, true);
+			OnClientConnected(Server()->MaxClients() -i-1, true, 0);
 	}
 #endif
 }
@@ -1532,11 +1548,6 @@ bool CGameContext::IsClientReady(int ClientID) const
 bool CGameContext::IsClientPlayer(int ClientID) const
 {
 	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetTeam() != TEAM_SPECTATORS;
-}
-
-bool CGameContext::IsClientSpectator(int ClientID) const
-{
-	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS;
 }
 
 const char *CGameContext::GameType() const { return m_pController && m_pController->GetGameType() ? m_pController->GetGameType() : ""; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -68,6 +68,12 @@ class CGameContext : public IGameServer
 	void Construct(int Resetting);
 
 	bool m_Resetting;
+
+	struct CPersistentClientData
+	{
+		bool m_IsSpectator;
+	};
+
 public:
 	IServer *Server() const { return m_pServer; }
 	class IConsole *Console() { return m_pConsole; }
@@ -163,8 +169,9 @@ public:
 
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID);
 
-	virtual void OnClientConnected(int ClientID, bool AsSpec) { OnClientConnected(ClientID, false, AsSpec); }
-	void OnClientConnected(int ClientID, bool Dummy, bool AsSpec);
+	virtual bool OnClientDataPersist(int ClientID, void *pData);
+	virtual void OnClientConnected(int ClientID, void *pPersistentData) { OnClientConnected(ClientID, false, (CPersistentClientData *)pPersistentData); }
+	void OnClientConnected(int ClientID, bool Dummy, CPersistentClientData *pPersistent);
 	void OnClientTeamChange(int ClientID);
 	virtual void OnClientEnter(int ClientID);
 	virtual void OnClientDrop(int ClientID, const char *pReason);
@@ -173,7 +180,7 @@ public:
 
 	virtual bool IsClientReady(int ClientID) const;
 	virtual bool IsClientPlayer(int ClientID) const;
-	virtual bool IsClientSpectator(int ClientID) const;
+	virtual int PersistentClientDataSize() const { return sizeof(CPersistentClientData); }
 
 	virtual const char *GameType() const;
 	virtual const char *Version() const;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -12,7 +12,7 @@ MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
 IServer *CPlayer::Server() const { return m_pGameServer->Server(); }
 
-CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool AsSpec)
+CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool Spec)
 {
 	m_pGameServer = pGameServer;
 	m_RespawnTick = Server()->Tick();
@@ -20,7 +20,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool AsSpe
 	m_ScoreStartTick = Server()->Tick();
 	m_pCharacter = 0;
 	m_ClientID = ClientID;
-	m_Team = AsSpec ? TEAM_SPECTATORS : GameServer()->m_pController->GetStartTeam();
+	m_Team = Spec ? TEAM_SPECTATORS : GameServer()->m_pController->GetStartTeam();
 	m_SpecMode = SPEC_FREEVIEW;
 	m_SpectatorID = -1;
 	m_pSpecFlag = 0;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -19,7 +19,7 @@ class CPlayer
 	MACRO_ALLOC_POOL_ID()
 
 public:
-	CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool AsSpec = false);
+	CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool Spec);
 	~CPlayer();
 
 	void Init(int CID);


### PR DESCRIPTION
upstream: https://www.github.com/teeworlds/teeworlds/pull/2066