### PR TITLE
Mark unused NETMSG_SNAPSMALL for 0.8 removal #3210

### DIFF
--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -44,7 +44,7 @@ enum
 	NETMSG_SNAP,			// normal snapshot, multiple parts
 	NETMSG_SNAPEMPTY,		// empty snapshot
 	NETMSG_SNAPSINGLE,		// ?
-	NETMSG_SNAPSMALL,		//
+	NETMSG_SNAPSMALL,		// todo 0.8: remove unused
 	NETMSG_INPUTTIMING,		// reports how off the input was
 	NETMSG_RCON_AUTH_ON,	// rcon authentication enabled
 	NETMSG_RCON_AUTH_OFF,	// rcon authentication disabled


### PR DESCRIPTION
upstream: https://www.github.com/teeworlds/teeworlds/pull/3210